### PR TITLE
Turn BrainMaGe into a BIDS app

### DIFF
--- a/BrainMaGe/utils/csv_creator_adv.py
+++ b/BrainMaGe/utils/csv_creator_adv.py
@@ -11,6 +11,7 @@ import os
 import sys
 import glob
 import re
+from bids import BIDSLayout
 
 
 def rex_o4a_csv(folder_path, to_save, ftype, modalities):
@@ -152,6 +153,60 @@ def rex_mul_csv(folder_path, to_save, ftype, modalities):
     csv_file.close()
 
 
+def rex_bids_csv(folder_path, to_save, ftype):
+    """[CSV generation for BIDS datasets]
+    [This function is used to generate a csv for BIDS datasets]
+    Arguments:
+        folder_path {[string]} -- [Takes the folder to see where to look for
+                                   the different modaliies]
+        to_save {[string]} -- [Takes the folder as a string to save the csv]
+        ftype {[string]} -- [Are you trying to save train, validation or test,
+                             if file type is set to test, it does not look for
+                             ground truths]
+    """
+    if ftype == 'test':
+        csv_file = open(os.path.join(to_save, ftype+'.csv'), 'w+')
+        csv_file.write('ID,')
+    else:
+        csv_file = open(os.path.join(to_save, ftype+'.csv'), 'w+')
+        csv_file.write('ID,gt_path,')
+    # load BIDS dataset into memory
+    layout = BIDSLayout(folder_path)
+    bids_df = layout.to_df()
+    bids_modality_df = {
+        't1': bids_df[bids_df['suffix'] == "T1w"],
+        't2': bids_df[bids_df['suffix'] == "T2w"],
+        'flair': bids_df[bids_df['suffix'] == "FLAIR"],
+        't1ce': bids_df[bids_df['suffix'] == "T1CE"]
+    }
+    # check what modalities the dataset contains
+    modalities = []
+    for modality, df in bids_modality_df.items():
+        if not df.empty:
+            modalities.append(modality)
+    # write headers for those modalities
+    for modality in modalities[:-1]:
+        csv_file.write(modality+'_path,')
+    modality = modalities[-1]
+    csv_file.write(modality+'_path\n')
+    # write image paths for each subject
+    for sub in layout.get_subjects():
+        csv_file.write(sub)
+        csv_file.write(',')
+        if ftype != 'test':
+            ground_truth = glob.glob(os.path.join(folder_path, sub, '*mask.nii.gz'))[0]
+            csv_file.write(ground_truth)
+            csv_file.write(',')
+        for modality in modalities[:-1]:
+            img = bids_modality_df[modality][bids_df['subject'] == sub].path.values
+            csv_file.write(img[1])
+            csv_file.write(',')
+        modality = modalities[-1]
+        img = bids_modality_df[modality][bids_df['subject'] == sub].path.values
+        csv_file.write(img[1])
+        csv_file.write('\n')
+    csv_file.close()
+
 def generate_csv(folder_path, to_save, mode, ftype, modalities):
     """[Function to generate CSV]
     [This function takes a look at the data directory and the modes and
@@ -163,13 +218,15 @@ def generate_csv(folder_path, to_save, mode, ftype, modalities):
         ftype {[string]} -- [description]
         modalities {[string]} -- [description]
     """
-    print("Generating", ftype, '.csv')
+    print("Generating ", ftype, '.csv', sep='')
     if mode.lower() == 'ma':
         rex_o4a_csv(folder_path, to_save, ftype, modalities)
     elif mode.lower() == 'single':
         rex_sin_csv(folder_path, to_save, ftype, modalities)
     elif mode.lower() == 'multi':
         rex_mul_csv(folder_path, to_save, ftype, modalities)
+    elif mode.lower() == 'bids':
+        rex_bids_csv(folder_path, to_save, ftype)
     else:
         print("Sorry, this mode is not supported")
         sys.exit(0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM continuumio/miniconda
+WORKDIR /src
+COPY . .
+SHELL ["/bin/bash", "-c"]
+RUN conda env create -f requirements.yml && conda init bash && source ~/.bashrc && conda activate brainmage && python setup.py install
+ENV CONDA_DEFAULT_ENV=brainmage PATH=/opt/conda/envs/brainmage/bin:$PATH
+ENTRYPOINT ["brain_mage_run"]
+CMD -v
+# docker build -t cbica/brainmage .

--- a/brain_mage_run
+++ b/brain_mage_run
@@ -109,7 +109,7 @@ if __name__ == '__main__':
                                      "resume during training. Please pass a .ckpt file.")
             elif args.test == 'True':
                 print(args.mode)
-                if args.mode.lower() == 'ma' or args.mode.lower == 'multi_4':
+                if args.mode.lower() == 'ma' or args.mode.lower() == 'multi_4' or args.mode.lower() == 'bids':
                     _, ext = os.path.splitext(weights)
                     if ext != '.pt':
                         raise ValueError("Expected a .pt file, got a file with %s extension. If it is a\n"+\
@@ -125,7 +125,7 @@ if __name__ == '__main__':
         elif args.test == 'True':
             base_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
             base_dir = os.path.join(os.path.dirname(base_dir), 'BrainMaGe/weights')
-            if args.mode.lower() == 'ma':
+            if args.mode.lower() == 'ma' or args.mode.lower() == 'bids':
                 weights = os.path.join(base_dir, 'resunet_ma.pt')
             elif args.mode.lower() == 'multi-4':
                 weights = os.path.join(base_dir, 'resunet_multi_4.pt')
@@ -151,7 +151,7 @@ if __name__ == '__main__':
     if args.train == 'True':
         trainer_main.train_network(params_file, DEVICE, weights)
     elif args.test == 'True':
-        if args.mode.lower() == 'ma':
+        if args.mode.lower() == 'ma' or args.mode.lower() == 'bids':
             test_ma.infer_ma(params_file, DEVICE, args.save_brain, weights)
         elif args.mode.lower() == 'multi-4':
             test_multi_4.infer_multi_4(params_file, DEVICE, args.save_brain, weights)

--- a/requirements.yml
+++ b/requirements.yml
@@ -333,4 +333,5 @@ dependencies:
     - rsa==4.6
     - tensorboard==2.2.2
     - tensorboard-plugin-wit==1.6.0.post3
+    - pybids==0.11.1
 prefix: /home/siddhesh/anaconda3/envs/deepbet


### PR DESCRIPTION
This PR adds a "BIDS" mode so rather than reading subjects from a provided CSV users could simply specify the path to their (BIDS) dataset, then individual image paths can be extracted using pybids. For example,
```
docker run \
-v $PWD/ds000001-download:/bids_dataset:ro \
-v $PWD/out:/path/to/output/directory \
cbica/brainmage -params ./BrainMaGe/config/test_params_ma.cfg -test True -mode BIDS -dev 0
```
with `test_dir = /bids_dataset` in `test_params_ma.cfg` will use all available modalities, writing out a CSV as the other modes do.

I noticed one of the TODOs in the README is to "Remove `-mode` parameter in `brain_mage_run`," so I'm not sure if this is the best approach, but if you are interested in incorporating a BIDS mode, I could refactor it to work another way.